### PR TITLE
fix: sendSMS was waiting for text to be sent. 

### DIFF
--- a/Sms.php
+++ b/Sms.php
@@ -115,7 +115,12 @@ class Sms
         if ($this->_pinOK) {
             $text = substr($text, 0, 160);
             $this->deviceOpen();
-            $this->sendMessage("AT+CMGS=\"{$tlfn}\"\r{$text}" . chr(26));
+            
+            $this->sendMessage("AT+CMGS={$tlfn}");
+            $this->sendMessage("\r");
+            $this->sendMessage($text);
+            $this->sendMessage(chr(26));
+            
             $out = $this->readPort();
 
             $this->deviceClose();


### PR DESCRIPTION
Hi,

Many thanks for your help with this script.

I tested your scripted and went into trouble on Schneider SR2.

It seems that when instructions are not sent separately, modem is waiting, showing '>' character.

Have a nice day
